### PR TITLE
Force pybuild to not create __pycache__ files at build

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,6 @@
 #! /usr/bin/make -f
 
-include /usr/share/dpkg/pkg-info.mk
+export PYTHONDONTWRITEBYTECODE=1
 
 # disable test for now (import test fails as conf file doesn't exist)
 export PYBUILD_DISABLE_python3=test


### PR DESCRIPTION
Minimal change to make ebsmount reproducible.